### PR TITLE
fix processing of dict-encapsulated sink mime support response

### DIFF
--- a/pulseaudio_dlna/plugins/dlna/renderer.py
+++ b/pulseaudio_dlna/plugins/dlna/renderer.py
@@ -201,6 +201,8 @@ class DLNAMediaRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
             d = self.upnp_device.get_protocol_info()
             sinks = d['GetProtocolInfoResponse']['Sink']
             # check if mime types are parsable
+            if type(sinks) is dict and '#text' in sinks:
+                sinks = sinks['#text']
             if type(sinks) is not str:
                 logger.warn("Could not parse mime types of type ")
                 logger.warn(type(sinks))


### PR DESCRIPTION
this change allows dicts in the form of
`{
  '@{http://www.w3.org/2001/XMLSchema-instance}type': 'xsd:string',
  '#text': '...<here goes the mime type list>...'
}`
to be processed as sink mime support response.

This change is required on my Linux Mint 20.3 for being able to correctly handshake sink mime type support of my SqueezeBoxes.
In fact they return the following dict instead of a plain string:
`{'@{http://www.w3.org/2001/XMLSchema-instance}type': 'xsd:string', '#text': 'http-get:*:audio/mpeg:*,http-get:*:audio/L16;rate=8000;channels=1:*,http-get:*:audio/L16;rate=8000;channels=2:*,http-get:*:audio/L16;rate=11025;channels=1:*,http-get:*:audio/L16;rate=11025;channels=2:*,http-get:*:audio/L16;rate=12000;channels=1:*,http-get:*:audio/L16;rate=12000;channels=2:*,http-get:*:audio/L16;rate=16000;channels=1:*,http-get:*:audio/L16;rate=16000;channels=2:*,http-get:*:audio/L16;rate=22050;channels=1:*,http-get:*:audio/L16;rate=22050;channels=2:*,http-get:*:audio/L16;rate=24000;channels=1:*,http-get:*:audio/L16;rate=24000;channels=2:*,http-get:*:audio/L16;rate=32000;channels=1:*,http-get:*:audio/L16;rate=32000;channels=2:*,http-get:*:audio/L16;rate=44100;channels=1:*,http-get:*:audio/L16;rate=44100;channels=2:*,http-get:*:audio/L16;rate=48000;channels=1:*,http-get:*:audio/L16;rate=48000;channels=2:*,http-get:*:audio/vnd.dlna.adts:*,http-get:*:audio/vnd.dlna.adts:*,http-get:*:audio/mp4:*,http-get:*:audio/mp4:*,http-get:*:audio/mp4:*,http-get:*:audio/x-ms-wma:*,http-get:*:audio/x-ms-wma:*,http-get:*:audio/x-ms-wma:*,http-get:*:application/ogg:*,http-get:*:audio/x-flac:*'}`

The original code required a plain string at this point. This small change extracts the mime type listing string from the dict, if required, before further processing.
I don't know whether this behavior is related to my (old) SqueezeBoxes, to the port of this project to Python3 or to the updated PyChromecast version (currently 13.0.4).
